### PR TITLE
Commenting out default instance of Monolog

### DIFF
--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -75,7 +75,8 @@ return [
 
 			'logging' => false,
 
-			'logObject' => \Log::getMonolog(),
+			// If you have an existing instance of Monolog you can use it here.
+			//'logObject' => \Log::getMonolog(),
 
 			'logPath' => storage_path('logs/elasticsearch.log'),
 


### PR DESCRIPTION
If Monolog is not instanced in your bootstrap this will fail. Default Laravel install does not have this loaded during config init.
