### PR TITLE
The service container's bindShared method has been deprecated in favo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 /vendor/
 /composer.lock
+.idea/.name
+.idea/deployment.xml
+.idea/encodings.xml
+.idea/laravel-elasticsearch.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,12 +41,13 @@ class ServiceProvider extends BaseServiceProvider {
 	 * @return void
 	 */
 	public function register() {
+		$app = $this->app;
 
-		$this->app->bindShared('elasticsearch.factory', function ($app) {
+		$app->singleton('elasticsearch.factory', function ($app) {
 			return new Factory();
 		});
 
-		$this->app->bindShared('elasticsearch', function ($app) {
+		$app->singleton('elasticsearch', function ($app) {
 			return new Manager($app, $app['elasticsearch.factory']);
 		});
 	}


### PR DESCRIPTION
The service container's bindShared method has been deprecated in favor of the singleton method.
This was removed entirely with the release of Laravel 5.2 in December 2015
