### PR TITLE
Lumen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you work with Lumen, please register the LumenServiceProvider:
 
 ```php
 
-$app->register(Dingo\Api\Provider\LumenServiceProvider::class);
+$app->register(Cviebrock\LaravelElasticsearch\LumenServiceProvider::class);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An easy way to use the official Elastic Search client in your Laravel applicatio
 <a name="installation"></a>
 ## Installation and Configuration
 
-Install the `cviebrock/laravel-elasticsearch` package via composer:
+Install the `khoatran/laravel-elasticsearch` package via composer:
 
 ```shell
 composer require cviebrock/laravel-elasticsearch
@@ -41,7 +41,7 @@ Add the service provider and facade (`config/app.php` for Laravel 5 or `app/conf
 ```php
 'providers' => [
     ...
-    Cviebrock\LaravelElasticsearch\ServiceProvider::class,
+    Cviebrock\LaravelElasticsearch\ServiceProvider::class, //=> Service provider for Laravel    
 ]
 
 'aliases' => [
@@ -49,6 +49,15 @@ Add the service provider and facade (`config/app.php` for Laravel 5 or `app/conf
     'Elasticsearch' => Cviebrock\LaravelElasticsearch\Facade::class,
 ]
 ```
+
+If you work with Lumen, please register the LumenServiceProvider:
+
+```php
+
+$app->register(Dingo\Api\Provider\LumenServiceProvider::class);
+
+```
+
 
 <a name="usage"></a>
 ## Usage
@@ -84,7 +93,11 @@ the configuration file).
 $return = Elasticsearch::connection('connectionName')->index($data);
 ```
 
-
+Please be noticed that you should not use Facade in Lumen. 
+So, in Lumen - you should use IoC or get the ElasticSearch service object from the application.
+```php
+$elasticSearch = $this->app('elasticsearch');
+```
 
 <a name="bugs"></a>
 ## Bugs, Suggestions and Contributions

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An easy way to use the official Elastic Search client in your Laravel applicatio
 <a name="installation"></a>
 ## Installation and Configuration
 
-Install the `khoatran/laravel-elasticsearch` package via composer:
+Install the `cviebrock/laravel-elasticsearch` package via composer:
 
 ```shell
 composer require cviebrock/laravel-elasticsearch

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "cviebrock/laravel-elasticsearch",
-	"description": "An easy way to use the official PHP ElasticSearch client in your Laravel applications",
+	"name": "khoatran/laravel-elasticsearch",
+	"description": "An easy way to use the official PHP ElasticSearch client in your Laravel applications. This repository is cloned from cviebrock/laravel-elasticsearch, but I make some changes to make it works with Lumen",
 	"keywords": [
 		"laravel",
 		"elasticsearch",
@@ -15,6 +15,10 @@
 	},
 	"license": "MIT",
 	"authors": [
+		{
+			"name": "Khoa Tran",
+			"email": "tran.dang.khoa.khtn@gmail.com"
+		},
 		{
 			"name": "Colin Viebrock",
 			"email": "colin@viebrock.ca"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "khoatran/laravel-elasticsearch",
-	"description": "An easy way to use the official PHP ElasticSearch client in your Laravel applications. This repository is cloned from cviebrock/laravel-elasticsearch, but I make some changes to make it works with Lumen",
+	"name": "cviebrock/laravel-elasticsearch",
+	"description": "An easy way to use the official PHP ElasticSearch client in your Laravel applications.",
 	"keywords": [
 		"laravel",
 		"elasticsearch",
@@ -15,10 +15,6 @@
 	},
 	"license": "MIT",
 	"authors": [
-		{
-			"name": "Khoa Tran",
-			"email": "tran.dang.khoa.khtn@gmail.com"
-		},
 		{
 			"name": "Colin Viebrock",
 			"email": "colin@viebrock.ca"

--- a/src/LumenManager.php
+++ b/src/LumenManager.php
@@ -1,0 +1,129 @@
+<?php namespace Cviebrock\LaravelElasticsearch;
+
+use Illuminate\Foundation\Application;
+
+
+/**
+ * Class Manager
+ *
+ * @package Cviebrock\LaravelElasticsearch
+ */
+class LumenManager {
+
+	/**
+	 * The application instance.
+	 *
+	 * @var \Illuminate\Foundation\Application
+	 */
+	protected $app;
+
+	/**
+	 * The Elasticsearch connection factory instance.
+	 *
+	 * @var Factory
+	 */
+	protected $factory;
+
+	/**
+	 * The active connection instances.
+	 *
+	 * @var array
+	 */
+	protected $connections = [];
+
+	/**
+	 * @param Application $app
+	 * @param Factory $factory
+	 */
+	public function __construct($app, Factory $factory) {
+
+		$this->app = $app;
+		$this->factory = $factory;
+	}
+
+	/**
+	 * Retrieve or build the named connection.
+	 *
+	 * @param null $name
+	 * @return \Elasticsearch\Client|mixed
+	 */
+	public function connection($name = null) {
+
+		$name = $name ?: $this->getDefaultConnection();
+
+		if (!isset($this->connections[$name])) {
+			$client = $this->makeConnection($name);
+
+			$this->connections[$name] = $client;
+		}
+
+		return $this->connections[$name];
+	}
+
+	/**
+	 * Get the default connection.
+	 *
+	 * @return string
+	 */
+	public function getDefaultConnection() {
+		return $this->app['config']['elasticsearch.defaultConnection'];
+	}
+
+	/**
+	 * Set the default connection.
+	 *
+	 * @param string $connection
+	 */
+	public function setDefaultConnection($connection) {
+		$this->app['config']['elasticsearch.defaultConnection'] = $connection;
+	}
+
+	/**
+	 * Make a new connection.
+	 *
+	 * @param $name
+	 * @return \Elasticsearch\Client|mixed
+	 */
+	protected function makeConnection($name) {
+		$config = $this->getConfig($name);
+
+		return $this->factory->make($config);
+	}
+
+	/**
+	 * Get the configuration for a named connection.
+	 *
+	 * @param $name
+	 * @return mixed
+	 */
+	protected function getConfig($name) {
+
+		$connections = $this->app['config']['elasticsearch.connections'];
+
+		if (is_null($config = array_get($connections, $name))) {
+			throw new \InvalidArgumentException("Elasticsearch connection [$name] not configured.");
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Return all of the created connections.
+	 *
+	 * @return array
+	 */
+	public function getConnections() {
+		return $this->connections;
+	}
+
+	/**
+	 * Dynamically pass methods to the default connection.
+	 *
+	 * @param  string $method
+	 * @param  array $parameters
+	 * @return mixed
+	 */
+	public function __call($method, $parameters) {
+		return call_user_func_array([$this->connection(), $method], $parameters);
+	}
+}

--- a/src/LumenServiceProvider.php
+++ b/src/LumenServiceProvider.php
@@ -1,0 +1,54 @@
+<?php namespace Cviebrock\LaravelElasticsearch;
+
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+
+
+/**
+ * Class ServiceProvider
+ *
+ * @package Cviebrock\LaravelElasticsearch
+ */
+class LumenServiceProvider extends BaseServiceProvider {
+
+	/**
+	 * Indicates if loading of the provider is deferred.
+	 *
+	 * @var bool
+	 */
+	protected $defer = false;
+
+	/**
+	 * Bootstrap the application events.
+	 *
+	 * @return void
+	 */
+	public function boot() {
+
+		$app = $this->app;
+
+		if (version_compare($app::VERSION, '5.0') >= 0) {
+			// Laravel 5
+			$configPath = realpath(__DIR__ . '/../config/elasticsearch.php');
+			$this->publishes([
+				$configPath => config_path('elasticsearch.php')
+			]);
+		}
+	}
+
+	/**
+	 * Register the service provider.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$app = $this->app;
+
+		$app->singleton('elasticsearch.factory', function ($app) {
+			return new Factory();
+		});
+
+		$app->singleton('elasticsearch', function ($app) {
+			return new LumenManager($app, $app['elasticsearch.factory']);
+		});
+	}
+}


### PR DESCRIPTION
I want to change a bit of the code to support Lumen 5.2 (not only the Laravel). The main problem if running this package on Lumen is: when initiate the Manager - it constrains the $app must be in Illuminate\Foundation\Application class. However, the application instance of Lumen is inherited from: Laravel\Lumen\Application. It causes the conflicts of the class type on the $app object.

My solution is: I create another different Manager class (LumenManager) and another ServiceProvider class (LumenServiceProvider). This approach may help in case in the future you want to add some more customization logic which are different between Lumen and Laravel initialization for the Manager. Then, inside the LumenManager constructor, I removed the class declaration for $app. 

I have tested this changes under my product and see it's working very well. I hope this PR useful. Currently, I still keep my clone of this package to use in my personal project. Let me know if you want to clarify more on the approach.
