### PR TITLE
automatically register the Facade for lumen

### DIFF
--- a/src/LumenServiceProvider.php
+++ b/src/LumenServiceProvider.php
@@ -36,5 +36,11 @@ class LumenServiceProvider extends BaseServiceProvider
         $app->singleton('elasticsearch', function($app) {
             return new LumenManager($app, $app['elasticsearch.factory']);
         });
+
+        $this->withFacades();
     }
+
+	protected function withFacades() {
+		class_alias('\Cviebrock\LaravelElasticsearch\Facade', 'Elasticsearch');
+	}
 }


### PR DESCRIPTION
When someone wants to use this package in Lumen with the Facade, he would need to add a few extra lines in his application to register the facade. 

This change is going to provide automatic registration of the facade. So now after it is accepted the documentation would be correct :)