### PR TITLE
configuration via .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Publish the configuration file:
 php artisan vendor:publish --provider="Cviebrock\LaravelElasticsearch\ServiceProvider"
 ```
 
+##### Alternative configuration method via .env file
+
+After you publish the configuration file as suggested above, you may configure Elastic Search
+by adding the following to laravel ```.env``` file
+  
+```ini
+ELASTICSEARCH_HOST=localhost
+ELASTICSEARCH_PORT=9200
+ELASTICSEARCH_SCHEME=http
+ELASTICSEARCH_USER=
+ELASTICSEARCH_PASS=
+```  
+
 ### Lumen
 
 If you work with Lumen, please register the LumenServiceProvider in `bootstrap/app.php`:

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -33,9 +33,15 @@ return [
              * @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_host_configuration
              */
 
-            'hosts' => [
-                'localhost:9200',
-            ],
+			'hosts' => [
+				[
+					'host' => env('ELASTICSEARCH_HOST', 'localhost'),
+					'port' => env('ELASTICSEARCH_PORT', 9200),
+					'scheme' => env('ELASTICSEARCH_SCHEME', null),
+					'user' => env('ELASTICSEARCH_USER', null),
+					'pass' => env('ELASTICSEARCH_PASS', null),
+				]
+			],
 
             /**
              * SSL


### PR DESCRIPTION
Configuration now done via extended host configuration https://github.com/elastic/elasticsearch-php/blob/master/docs/configuration.asciidoc#extended-host-configuration 

Ability to configure elastic search via .env file.