### PR TITLE
Support class injection of elasticsearch

### DIFF
--- a/src/LumenServiceProvider.php
+++ b/src/LumenServiceProvider.php
@@ -34,6 +34,8 @@ class LumenServiceProvider extends BaseServiceProvider
         $app->singleton('elasticsearch', function($app) {
             return new LumenManager($app, $app['elasticsearch.factory']);
         });
+        
+        $app->alias('elasticsearch', LumenManager::class);
 
         $this->withFacades();
     }


### PR DESCRIPTION
For easier injection of elastic search into other classes, I've added an alias to class name.

**example**
So now you can inject elastic search into command handle method for example.

```php
public function handle(LumenManager $lm)
{
  $lm->ping()
}
```