### PR TITLE
Elastic v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0 - 29-Nov-2017
+
+- Bump ES client version to ^6.0
+
 ## 2.1.0 - 31-Aug-2017
 
 - Laravel 5.5 support, including auto-registration

--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ An easy way to use the [official Elastic Search client](https://github.com/elast
 
 ## Installation and Configuration
 
-Install the `cviebrock/laravel-elasticsearch` package via composer:
+Install the current version of the `cviebrock/laravel-elasticsearch` package via composer:
 
 ```sh
 composer require cviebrock/laravel-elasticsearch
+```
+
+If you are using ElasticSearch version 5, then use version 2
+
+```sh
+composer require cviebrock/laravel-elasticsearch:^2
 ```
 
 ### Laravel

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "elasticsearch/elasticsearch": "^5.3",
+        "elasticsearch/elasticsearch": "^6.0",
         "illuminate/support": "~5.5.0",
         "monolog/monolog": "^1.23"
     },


### PR DESCRIPTION
Simple version bump for ES client, together with readme and changelog. Recommend tagging as 3.0.0.