### PR TITLE
Fix Lumen $app class injection error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An easy way to use the [official Elastic Search client](https://github.com/elast
 
 * [Installation and Configuration](#installation-and-configuration)
 * [Usage](#usage)
+* [Advanced Usage](#advanced-usage)
 * [Bugs, Suggestions and Contributions](#bugs-suggestions-and-contributions)
 * [Copyright and License](#copyright-and-license)
 
@@ -96,6 +97,16 @@ the configuration file).
 
 ```php
 $return = Elasticsearch::connection('connectionName')->index($data);
+```
+
+Lumen users who wish to use Facades can do so by editing their bootstrap/app.php file to include
+the following:
+```php
+$app->withFacades(true, [
+        ...
+        '\Cviebrock\LaravelElasticsearch\Facade' => 'Elasticsearch',
+        ...
+]);
 ```
 
 Lumen users who aren't using facades will need to use dependency injection or the application container

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -3,7 +3,6 @@
 use Elasticsearch\Client;
 use Illuminate\Contracts\Container\Container;
 
-
 /**
  * Class Manager
  *

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,7 +1,7 @@
 <?php namespace Cviebrock\LaravelElasticsearch;
 
 use Elasticsearch\Client;
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container;
 
 
 /**
@@ -15,7 +15,7 @@ class Manager
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $app;
 
@@ -34,10 +34,10 @@ class Manager
     protected $connections = [];
 
     /**
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Illuminate\Contracts\Container\Container $app
      * @param \Cviebrock\LaravelElasticsearch\Factory $factory
      */
-    public function __construct(Application $app, Factory $factory)
+    public function __construct(Container $app, Factory $factory)
     {
         $this->app = $app;
         $this->factory = $factory;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -44,10 +44,6 @@ class ServiceProvider extends BaseServiceProvider
         $app->singleton(Client::class, function($app) {
             return $app['elasticsearch']->connection();
         });
-
-        if ($app instanceof LumenApplication) {
-            $this->withLumenFacades();
-        }
     }
 
     protected function setUpConfig()
@@ -61,10 +57,5 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         $this->mergeConfigFrom($source, 'elasticsearch');
-    }
-
-    protected function withLumenFacades()
-    {
-        class_alias(Facade::class, 'Elasticsearch');
     }
 }


### PR DESCRIPTION
This fixes a major Lumen bug introduced in version 2.1, when service providers were merged. This wasn't immediately apparent as 2.1 wasn't tagged on github, but become more obvious when it was carried forward into version 3.0.

The Manager class expected to receive an instance of Illuminate\Contracts\Foundation\Application, but that's the interface for the Laravel application class only, Lumen doesn't implement it and instead extends the Container directly. Causing the following fatal error when using Lumen:

> Type error: Argument 1 passed to Cviebrock\LaravelElasticsearch\Manager::__construct() must be an instance of Illuminate\Contracts\Foundation\Application, instance of Laravel\Lumen\Application given.

Since the Laravel Application class also extends the Container, this is Laravel and Lumen's highest common ancestor and so this fix switches the Manager class's typehinting to the Container interface.