### PR TITLE
Support for Laravel 5.6 - fixes #39

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^7.0",
         "elasticsearch/elasticsearch": "^6.0",
-        "illuminate/support": "~5.5.0",
+        "illuminate/support": "~5.5.0|~5.6.0",
         "monolog/monolog": "^1.23"
     },
     "require-dev": {
-        "codedungeon/phpunit-result-printer": "^0.4.4",
-        "orchestra/testbench": "~3.5.0",
-        "phpunit/phpunit": "^6.2"
+        "codedungeon/phpunit-result-printer": "^0.6.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0",
+        "phpunit/phpunit": "^6.2|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "monolog/monolog": "^1.23"
     },
     "require-dev": {
-        "codedungeon/phpunit-result-printer": "^0.6.0",
+        "codedungeon/phpunit-result-printer": "^0.4.4|^0.6.0",
         "orchestra/testbench": "~3.5.0|~3.6.0",
         "phpunit/phpunit": "^6.2|^7.0"
     },


### PR DESCRIPTION
This PR allows the installation of this module on Laravel 5.6 by allowing illuminate support 5.6,  phpunit 7.0, orchestra testbench 3.6 and phpunit-result-printer 0.6.0.
Fixes issue #39 