### PR TITLE
Elasticsearch supports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.0",
         "elasticsearch/elasticsearch": "^6.0",
+        "aws/aws-sdk-php": "^3.80",
         "laravel/framework": "~5.5.0|~5.6.0|~5.7.0",
         "monolog/monolog": "^1.23"
     },

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -41,11 +41,15 @@ return [
 
             'hosts' => [
                 [
-                    'host'   => env('ELASTICSEARCH_HOST', 'localhost'),
-                    'port'   => env('ELASTICSEARCH_PORT', 9200),
-                    'scheme' => env('ELASTICSEARCH_SCHEME', null),
-                    'user'   => env('ELASTICSEARCH_USER', null),
-                    'pass'   => env('ELASTICSEARCH_PASS', null),
+                    'host'       => env('ELASTICSEARCH_HOST', 'localhost'),
+                    'port'       => env('ELASTICSEARCH_PORT', 9200),
+                    'scheme'     => env('ELASTICSEARCH_SCHEME', null),
+                    'user'       => env('ELASTICSEARCH_USER', null),
+                    'pass'       => env('ELASTICSEARCH_PASS', null),
+                    'aws'        => env('AWS_ELASTICSEARCH_ENABLED', false),
+                    'aws_region' => env('AWS_REGION', ''),
+                    'aws_key'    => env('AWS_ACCESS_KEY_ID', ''),
+                    'aws_secret' => env('AWS_SECRET_ACCESS_KEY', '')
                 ],
             ],
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -78,6 +78,46 @@ class Factory
             }
         }
 
+        foreach($config['hosts'] as $c) {
+            if( $c['aws'] ) {
+                echo "hola";
+                $clientBuilder->setHandler( function(array $request) use($c) {
+                    $psr7Handler = \Aws\default_http_handler();
+                    $signer = new \Aws\Signature\SignatureV4('es', $c['aws_region']);
+                    $request['headers']['Host'][0] = parse_url($request['headers']['Host'][0])['host'];
+                    // Create a PSR-7 request from the array passed to the handler
+                    $psr7Request = new \GuzzleHttp\Psr7\Request(
+                        $request['http_method'],
+                        (new \GuzzleHttp\Psr7\Uri($request['uri']))
+                            ->withScheme($request['scheme'])
+                            ->withHost($request['headers']['Host'][0]),
+                        $request['headers'],
+                        $request['body']
+                    );
+                    // Sign the PSR-7 request with credentials from the environment
+                    $signedRequest = $signer->signRequest(
+                        $psr7Request,
+                        new \Aws\Credentials\Credentials($c['aws_key'], $c['aws_secret'])
+                    );
+                    // Send the signed request to Amazon ES
+                    /** @var \Psr\Http\Message\ResponseInterface $response */
+                    $response = $psr7Handler($signedRequest)->then(function (\Psr\Http\Message\ResponseInterface $response) {
+                        return $response;
+                    }, function ($error) {
+                        return $error['response'];
+                    })->wait();
+                    // Convert the PSR-7 response to a RingPHP response
+                    return new \GuzzleHttp\Ring\Future\CompletedFutureArray([
+                        'status' => $response->getStatusCode(),
+                        'headers' => $response->getHeaders(),
+                        'body' => $response->getBody()->detach(),
+                        'transfer_stats' => ['total_time' => 0],
+                        'effective_url' => (string)$psr7Request->getUri(),
+                    ]);
+                });
+            }else echo "no hola!";
+        }
+
         // Build and return the client
 
         return $clientBuilder->build();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -80,7 +80,6 @@ class Factory
 
         foreach($config['hosts'] as $c) {
             if( $c['aws'] ) {
-                echo "hola";
                 $clientBuilder->setHandler( function(array $request) use($c) {
                     $psr7Handler = \Aws\default_http_handler();
                     $signer = new \Aws\Signature\SignatureV4('es', $c['aws_region']);
@@ -115,7 +114,7 @@ class Factory
                         'effective_url' => (string)$psr7Request->getUri(),
                     ]);
                 });
-            }else echo "no hola!";
+            }
         }
 
         // Build and return the client


### PR DESCRIPTION
Hi,

I would like to thank you for your library. I needed to use it with Elasticsearch, so I made some changes to permits the connection with 'AWS_ACCESS_KEY_ID' and 'AWS_SECRET_ACCESS_KEY'.
In the config file I added only the credentials for the AWS Elasticsearch instance and a flag to enable/disable it.
`'aws'        => env('AWS_ELASTICSEARCH_ENABLED', false)`
`'aws_region' => env('AWS_REGION', '')`
`'aws_key'    => env('AWS_ACCESS_KEY_ID', '')`
`'aws_secret' => env('AWS_SECRET_ACCESS_KEY', '')`

As you can see, all the configurations could be inserted on the .env file. 

