### PR TITLE
strictly check 'aws' key existence before using it as boolean

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -84,7 +84,7 @@ class Factory
         // Configure handlers for any AWS hosts
 
         foreach ($config['hosts'] as $host) {
-            if ($host['aws']) {
+            if (isset($host['aws']) && $host['aws']) {
                 $clientBuilder->setHandler(function(array $request) use ($host) {
                     $psr7Handler = \Aws\default_http_handler();
                     $signer = new \Aws\Signature\SignatureV4('es', $host['aws_region']);


### PR DESCRIPTION
Thanks @Matrix86 for adding aws support. But, using 'aws' key directly without checking existence broke our projects that we enable notice error messages. This will fix.
