### PR TITLE
Require illuminate/support & illuminate/contracts instead of the whole laravel framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "^7.0",
         "elasticsearch/elasticsearch": "^6.0",
-        "laravel/framework": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0",
         "monolog/monolog": "^1.23"
     },
     "require-dev": {


### PR DESCRIPTION
These packages are being used in the code.

Resolve this [issue](https://github.com/cviebrock/laravel-elasticsearch/issues/47)