### PR TITLE
Update composer.json for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": "^7.0",
         "elasticsearch/elasticsearch": "^6.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "monolog/monolog": "^1.23"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 5.8 requires 5.8.x versions of illuminate libraries.

Both dependencies do not seem to have breaking changes, so I think the new version can be safely allowed.