### PR TITLE
Fix #58: Replace removed method ClientBuilder::defaultLogger with a f…

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,6 +3,8 @@
 use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder;
 use Psr\Log\LoggerInterface;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
 
 class Factory
 {
@@ -63,7 +65,9 @@ class Factory
             if ($logObject && $logObject instanceof LoggerInterface) {
                 $clientBuilder->setLogger($logObject);
             } elseif ($logPath && $logLevel) {
-                $logObject = ClientBuilder::defaultLogger($logPath, $logLevel);
+                $handler = new StreamHandler($logPath, $logLevel);
+                $logObject = new Logger('log');
+                $logObject->pushHandler($handler);
                 $clientBuilder->setLogger($logObject);
             }
         }


### PR DESCRIPTION
Fix #58: Replace removed method ClientBuilder::defaultLogger with a falback Monolog Logger

Change affect users with "logging" config set to true,  "logPath" and "logLevel" set, and no "logObject" configured.

- [X] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [X] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [ ] added tests
- [ ] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [X] only submitted one pull request per feature

**Thank you!**
