### PR TITLE
add tracer

### DIFF
--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -188,7 +188,16 @@ return [
              * @example 'namespaces' => [XPack::Security(), XPack::Watcher()]
              * @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/ElasticsearchPHP_Endpoints.html#Elasticsearch_ClientBuilderregisterNamespace_registerNamespace
              */
-            'namespaces' => []
+            'namespaces' => [],
+
+            /**
+             * Tracer
+             *
+             * Tracer is handled by passing in a name of the class implements Psr\Log\LoggerInterface.
+             *
+             * @see https://www.elastic.co/guide/en/elasticsearch/client/php-api/2.0/_configuration.html#_setting_a_custom_connectionfactory
+             */
+            'tracer' => null,
 
         ],
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -72,6 +72,11 @@ class Factory
             }
         }
 
+        // Configure tracer
+        if ($tracer = array_get($config, 'tracer')) {
+            $clientBuilder->setTracer(app($tracer));
+        }
+
         // Set additional client configuration
 
         foreach ($this->configMappings as $key => $method) {


### PR DESCRIPTION
Allowed to pass a tracer to receive request log. In some cases, for tracing, the request event can be triggered via the tracer.