### PR TITLE
Update the composer.json so it requires elasticsearch client version to at least 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"elasticsearch/elasticsearch": "^5.0",
+		"elasticsearch/elasticsearch": "^5.4",
 		"illuminate/support": "~5",
 		"monolog/monolog": "~1"
 	},


### PR DESCRIPTION
A change that makes elasticsearch version 5 still work under PHP 7.3. This is the related issue that fixes it https://github.com/elastic/elasticsearch-php/issues/798
