### PR TITLE
Renew custom credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ An easy way to use the [official Elastic Search client](https://github.com/elast
 [![Latest Stable Version](https://poser.pugx.org/cviebrock/laravel-elasticsearch/v/unstable.png)](https://packagist.org/packages/cviebrock/laravel-elasticsearch)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/cviebrock/laravel-elasticsearch/badges/quality-score.png?format=flat)](https://scrutinizer-ci.com/g/cviebrock/laravel-elasticsearch)
 
-- [Installation and Configuration](#installation-and-configuration)
-  - [Laravel](#laravel)
-      - [Alternative configuration method via .env file](#alternative-configuration-method-via-env-file)
-      - [Connecting to AWS Elasticsearch Service](#connecting-to-aws-elasticsearch-service)
-  - [Lumen](#lumen)
-- [Usage](#usage)
-- [Advanced Usage](#advanced-usage)
-- [Bugs, Suggestions, Contributions and Support](#bugs-suggestions-contributions-and-support)
-- [Copyright and License](#copyright-and-license)
+- [Laravel-Elasticsearch](#laravel-elasticsearch)
+  - [Installation and Configuration](#installation-and-configuration)
+    - [Laravel](#laravel)
+        - [Alternative configuration method via .env file](#alternative-configuration-method-via-env-file)
+        - [Connecting to AWS Elasticsearch Service](#connecting-to-aws-elasticsearch-service)
+    - [Lumen](#lumen)
+  - [Usage](#usage)
+  - [Advanced Usage](#advanced-usage)
+  - [Bugs, Suggestions, Contributions and Support](#bugs-suggestions-contributions-and-support)
+  - [Copyright and License](#copyright-and-license)
 
 
 
@@ -97,6 +98,23 @@ $credentials = call_user_func( $memoizedProvider )->wait();
     ],
 ],
 
+```
+
+If you have a job that runs in supervisor, you have to use the Closure, this way the credentials will be renewed at runtime.
+
+```php
+<?php
+
+// config/elasticsearch.php
+$provider = \Aws\Credentials\CredentialProvider::instanceProfile();
+$memoizedProvider = \Aws\Credentials\CredentialProvider::memoize($provider);
+....
+'hosts' => [
+    [
+        ....
+        'aws_credentials' => $memoizedProvider
+    ],
+],
 
 ```
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -118,6 +118,11 @@ class Factory
                         $credentials = $host['aws_credentials'];
                     }
 
+                    if (!empty($host['aws_credentials']) && $host['aws_credentials'] instanceof \Closure) {
+                        // If it contains a closure you can obtain the credentials by invoking it
+                        $credentials = $host['aws_credentials']()->wait();
+                    }
+
                     // Sign the PSR-7 request
                     $signedRequest = $signer->signRequest(
                         $psr7Request,


### PR DESCRIPTION
This PR fixes a bug: if you use custom credentials (i.e. instanceProfile) they will not be renewed if the execution runs in a cron job (i.e. supervisor).
Using the Closure, the credentials will be renewed every time a client will be instatiated. 
