### PR TITLE
Added AWS Session Token support (needed when run on Lambda)

### DIFF
--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -41,18 +41,19 @@ return [
 
             'hosts' => [
                 [
-                    'host'            => env('ELASTICSEARCH_HOST', 'localhost'),
-                    'port'            => env('ELASTICSEARCH_PORT', 9200),
-                    'scheme'          => env('ELASTICSEARCH_SCHEME', null),
-                    'user'            => env('ELASTICSEARCH_USER', null),
-                    'pass'            => env('ELASTICSEARCH_PASS', null),
+                    'host'              => env('ELASTICSEARCH_HOST', 'localhost'),
+                    'port'              => env('ELASTICSEARCH_PORT', 9200),
+                    'scheme'            => env('ELASTICSEARCH_SCHEME', null),
+                    'user'              => env('ELASTICSEARCH_USER', null),
+                    'pass'              => env('ELASTICSEARCH_PASS', null),
 
                     // If you are connecting to an Elasticsearch instance on AWS, you will need these values as well
-                    'aws'             => env('AWS_ELASTICSEARCH_ENABLED', false),
-                    'aws_region'      => env('AWS_REGION', ''),
-                    'aws_key'         => env('AWS_ACCESS_KEY_ID', ''),
-                    'aws_secret'      => env('AWS_SECRET_ACCESS_KEY', ''),
-                    'aws_credentials' => null
+                    'aws'               => env('AWS_ELASTICSEARCH_ENABLED', false),
+                    'aws_region'        => env('AWS_REGION', ''),
+                    'aws_key'           => env('AWS_ACCESS_KEY_ID', ''),
+                    'aws_secret'        => env('AWS_SECRET_ACCESS_KEY', ''),
+                    'aws_credentials'   => null,
+                    'aws_session_token' => env('AWS_SESSION_TOKEN', null),
                 ],
             ],
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -111,7 +111,11 @@ class Factory
                     );
                     
                     // Create the Credentials instance with the credentials from the environment
-                    $credentials = new \Aws\Credentials\Credentials($host['aws_key'], $host['aws_secret']);
+                    $credentials = new \Aws\Credentials\Credentials(
+                        $host['aws_key'],
+                        $host['aws_secret'],
+                        $host['aws_session_token'] ?? null
+                    );
                     // check if the aws_credentials from config is set and if it contains a Credentials instance
                     if (!empty($host['aws_credentials']) && $host['aws_credentials'] instanceof \Aws\Credentials\Credentials) {
                         // Set the credentials as in config


### PR DESCRIPTION
Added AWS Session Token support (needed when run on Lambda).

This is only a draft/suggestion, because I had to add the retrieval of that env var in order to make it works on Lambda function.