### PR TITLE
changed index create command in order to be coherent with others

### DIFF
--- a/src/Console/Command/IndexCreateCommand.php
+++ b/src/Console/Command/IndexCreateCommand.php
@@ -8,7 +8,7 @@ use Elasticsearch\Client;
 use Illuminate\Console\Command;
 use Throwable;
 
-final class CreateIndexCommand extends Command
+final class IndexCreateCommand extends Command
 {
     /**
      * @var string

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,7 @@
 use Cviebrock\LaravelElasticsearch\Console\Command\AliasCreateCommand;
 use Cviebrock\LaravelElasticsearch\Console\Command\AliasRemoveIndexCommand;
 use Cviebrock\LaravelElasticsearch\Console\Command\AliasSwitchIndexCommand;
-use Cviebrock\LaravelElasticsearch\Console\Command\CreateIndexCommand;
+use Cviebrock\LaravelElasticsearch\Console\Command\IndexCreateCommand;
 use Cviebrock\LaravelElasticsearch\Console\Command\IndexDeleteCommand;
 use Cviebrock\LaravelElasticsearch\Console\Command\IndexExistsCommand;
 use Elasticsearch\Client;
@@ -74,7 +74,7 @@ class ServiceProvider extends BaseServiceProvider
                 AliasCreateCommand::class,
                 AliasRemoveIndexCommand::class,
                 AliasSwitchIndexCommand::class,
-                CreateIndexCommand::class,
+                IndexCreateCommand::class,
                 IndexDeleteCommand::class,
                 IndexExistsCommand::class,
             ]);

--- a/tests/Console/Command/IndexCreateCommandTest.php
+++ b/tests/Console/Command/IndexCreateCommandTest.php
@@ -11,7 +11,7 @@ use Exception;
 use Generator;
 use Mockery\MockInterface;
 
-final class CreateIndexCommandTest extends TestCase
+final class IndexCreateCommandTest extends TestCase
 {
     public function testCreateIndexMustSucceed(): void
     {


### PR DESCRIPTION
Changed index create command class name in order to be coherent with others: before was `CreateIndexCommand`, now `IndexCreateCommand`.