### PR TITLE
Ability to create new index with settings/mappings on IndexCreateOrUpdateMappingCommand

### DIFF
--- a/src/Console/Command/IndexCreateOrUpdateMappingCommand.php
+++ b/src/Console/Command/IndexCreateOrUpdateMappingCommand.php
@@ -55,14 +55,36 @@ final class IndexCreateOrUpdateMappingCommand extends Command
         if (!$this->client->indices()->exists([
             'index' => $indexName,
         ])) {
+            try {
+                $this->client->indices()->create([
+                    'index' => $indexName,
+                    'body'  => json_decode(
+                        $this->filesystem->get($mappingFilePath),
+                        true
+                    ),
+                ]);
+            } catch (Throwable $exception) {
+                $this->output->writeln(
+                    sprintf(
+                        '<error>Error creating or updating mapping for index %s, given mapping file: %s - error message: %s.</error>',
+                        $indexName,
+                        $mappingFilePath,
+                        $exception->getMessage()
+                    )
+                );
+
+                return self::FAILURE;
+            }
+
             $this->output->writeln(
                 sprintf(
-                    '<error>Index %s doesn\'t exists and mapping cannot be created or updated.</error>',
-                    $indexName
+                    '<info>Index and Mapping created for index %s using file %s.</info>',
+                    $indexName,
+                    $mappingFilePath
                 )
             );
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
         try {

--- a/src/Console/Command/IndexCreateOrUpdateMappingCommand.php
+++ b/src/Console/Command/IndexCreateOrUpdateMappingCommand.php
@@ -78,7 +78,7 @@ final class IndexCreateOrUpdateMappingCommand extends Command
 
             $this->output->writeln(
                 sprintf(
-                    '<info>Index and Mapping created for index %s using file %s.</info>',
+                    '<info>Index %s doesn\'t exist, a new index was created with mapping/settings using file %s.</info>',
                     $indexName,
                     $mappingFilePath
                 )

--- a/tests/Console/Command/IndexCreateOrUpdateMappingCommandTest.php
+++ b/tests/Console/Command/IndexCreateOrUpdateMappingCommandTest.php
@@ -79,7 +79,11 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
         $this->mock(Filesystem::class, function (MockInterface $mock) {
             $mock->shouldReceive('exists')
                 ->once()
-                ->andReturn(false);
+                ->andReturn(true);
+
+            $mock->shouldReceive('get')
+                ->once()
+                ->andReturn('{}');
         });
 
         $this->mock(Client::class, function (MockInterface $mock) {
@@ -91,7 +95,9 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
                             ->once()
                             ->andReturn(false);
 
-                        $mock->shouldReceive('create');
+                        $mock->shouldReceive('create')
+                            ->once()
+                            ->andReturn(true);
                     })
                 );
         });
@@ -102,8 +108,8 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
                 'index-name' => 'valid_index_name',
                 'mapping-file-path' => '/path/to/existing_mapping_file.json',
             ]
-        )->assertExitCode(1)
-            ->expectsOutput('Index valid_index_name doesn\'t exists, new index created with mapping/settings.');
+        )->assertExitCode(0)
+            ->expectsOutput('Index valid_index_name doesn\'t exist, a new index was created with mapping/settings using file /path/to/existing_mapping_file.json.');
     }
 
     public function testCreateOrUpdateMappingMustFail(): void

--- a/tests/Console/Command/IndexCreateOrUpdateMappingCommandTest.php
+++ b/tests/Console/Command/IndexCreateOrUpdateMappingCommandTest.php
@@ -20,7 +20,7 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
             $mock->shouldReceive('exists')
                 ->once()
                 ->andReturn(true);
-            
+
             $mock->shouldReceive('get')
                 ->once()
                 ->andReturn('{}');
@@ -74,24 +74,24 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
             ->expectsOutput('Argument mapping-file-path must exists on filesystem and must be a non empty string.');
     }
 
-    public function testCreateOrUpdateMappingMustFailBecauseIndexDoesntExists(): void
+    public function testCreateOrUpdateMappingMustCreateNewIndexIfIndexDoesntExists(): void
     {
         $this->mock(Filesystem::class, function (MockInterface $mock) {
             $mock->shouldReceive('exists')
                 ->once()
-                ->andReturn(true);
+                ->andReturn(false);
         });
 
         $this->mock(Client::class, function (MockInterface $mock) {
             $mock->shouldReceive('indices')
-                ->once()
+                ->times(2)
                 ->andReturn(
                     $this->mock(IndicesNamespace::class, function (MockInterface $mock) {
                         $mock->shouldReceive('exists')
                             ->once()
                             ->andReturn(false);
 
-                        $mock->shouldNotReceive('putMapping');
+                        $mock->shouldReceive('create');
                     })
                 );
         });
@@ -103,7 +103,7 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
                 'mapping-file-path' => '/path/to/existing_mapping_file.json',
             ]
         )->assertExitCode(1)
-            ->expectsOutput('Index valid_index_name doesn\'t exists and mapping cannot be created or updated.');
+            ->expectsOutput('Index valid_index_name doesn\'t exists, new index created with mapping/settings.');
     }
 
     public function testCreateOrUpdateMappingMustFail(): void
@@ -112,7 +112,7 @@ final class IndexCreateOrUpdateMappingCommandTest extends TestCase
             $mock->shouldReceive('exists')
                 ->once()
                 ->andReturn(true);
-            
+
             $mock->shouldReceive('get')
                 ->once()
                 ->andReturn('{}');


### PR DESCRIPTION
Added the ability to create a new index with it's mapping. Originally this would fail complaining the index does not exist which was the intended behaviour.

Why?
This makes it easier to create a new index with the mapping in one shot and adds the ability to create the index with it's settings. We can create a separate command to update the settings of the index but some settings in Elasticsearch index need to be provided at create.

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [x] added tests
- [x] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature
