### PR TITLE
Ability to cache config when using a Closure for AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ $memoizedProvider = \Aws\Credentials\CredentialProvider::memoize($provider);
 ],
 ```
 
+If you are using `php artisan config:cache`, you cannot have the Closure in your config file, call it like this:
+
+```php
+<?php
+// config/elasticsearch.php
+
+...
+
+'hosts' => [
+    [
+        ...
+        'aws_credentials' => [\Aws\Credentials\CredentialProvider::class, 'defaultProvider'],
+    ],
+],
+```
+
 ### Lumen
 
 If you work with Lumen, please register the service provider and configuration in `bootstrap/app.php`:

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Ring\Future\CompletedFutureArray;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Reflector;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Monolog\Logger;
@@ -121,6 +122,15 @@ class Factory
                     if (!empty($host['aws_credentials']) && $host['aws_credentials'] instanceof \Aws\Credentials\Credentials) {
                         // Set the credentials as in config
                         $credentials = $host['aws_credentials'];
+                    }
+
+                    // If the aws_credentials is an array try using it as a static method of the class
+                    if (
+                        !empty($host['aws_credentials'])
+                        && is_array($host['aws_credentials'])
+                        && Reflector::isCallable($host['aws_credentials'], true)
+                    ) {
+                        $host['aws_credentials'] = call_user_func([$host['aws_credentials'][0], $host['aws_credentials'][1]]);
                     }
 
                     if (!empty($host['aws_credentials']) && $host['aws_credentials'] instanceof \Closure) {


### PR DESCRIPTION
Hi,

I want to make it work with Laravel Vapor, but the only working way is to use closures because Vapor injects `AWS_SESSION_TOKEN`  in AWS Lambda after the actual deployment.

Vapor uses `php artisan config:cache` under the [hood](https://github.com/laravel/vapor-core/blob/2.0/stubs/fpmRuntime.php#L65) and any closure in the config throws a [LogicException](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/ConfigCacheCommand.php#L71).

I suggest passing the Closure method to `aws_credentials` as an array, as in the Route facade.