### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   strategy:
    fail-fast: true
    matrix:
-    php: [7.3, 7.4]
+    php: [7.3, 7.4, 8.0]
     elastic: [7.10.0]
     stability: [prefer-lowest, prefer-stable]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.4 - 24-Feb-2021
+
+- Add PHP 8.0 Support
+
 ## 8.0.3 - 28-Dec-2020
 
 - Support using a closure for AWS credentials, allowing the config to be cached (#111, thanks @stasadev)

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
-        "elasticsearch/elasticsearch": "^7.10",
+        "elasticsearch/elasticsearch": "^7.11",
         "guzzlehttp/psr7": "^1.7",
         "illuminate/contracts": "^8.0",
         "illuminate/support": "^8.0",
@@ -27,6 +27,7 @@
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^6.0",
         "orchestra/testbench": "^6.5",
+        "mockery/mockery": "^1.4.3",
         "phpunit/phpunit": "^9.4"
     },
     "suggest": {


### PR DESCRIPTION
The official Elasticsearch PHP client now supports PHP 8.0 [since v7.11](https://github.com/elastic/elasticsearch-php/releases/tag/v7.11.0). 

I thought it might be a good idea to update laravel-elasticsearch as well. 

I have:

* Updated composer.json.
* Added PHP 8.0 to the Github Actions test matrix.
* Added Mockery 1.4.3 as a minimum to require-dev, because 1.3.* had some semver-unfriendly PHP 8 incompatibilities.

The Github Actions test workflow [completes succesfully](https://github.com/okdewit/laravel-elasticsearch/actions/runs/596392271) on the fork for all PHP/Laravel combinations.
