### PR TITLE
Fix host assignment

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -99,7 +99,7 @@ class Factory
                 $clientBuilder->setHandler(function(array $request) use ($host) {
                     $psr7Handler = \Aws\default_http_handler();
                     $signer = new \Aws\Signature\SignatureV4('es', $host['aws_region']);
-                    $request['headers']['Host'][0] = parse_url($request['headers']['Host'][0])['host'];
+                    $request['headers']['Host'][0] = parse_url($request['headers']['Host'][0])['host'] ?? $request['headers']['Host'][0];
 
                     // Create a PSR-7 request from the array passed to the handler
                     $psr7Request = new Request(


### PR DESCRIPTION
I try connecting to remote ES instance from Docker with this config:

AWS_ELASTICSEARCH_ENABLED=true
ELASTICSEARCH_HOST=XXX.XXX.XXX.XXX
ELASTICSEARCH_PORT=9200
ELASTICSEARCH_SCHEME=http
ELASTICSEARCH_USER=
ELASTICSEARCH_PASS=

I get an error because the request has not "host" key. The host is in the request, I don't need parse the url. With this change, I get a successfull connection.
