### PR TITLE
Change the env variable name for AWS region

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ need to `composer require aws/aws-sdk-php:^3.80` and add the following to your
 
 ```ini
 AWS_ELASTICSEARCH_ENABLED=true
-AWS_REGION=...
+AWS_DEFAULT_REGION=...
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
@@ -95,7 +95,7 @@ $credentials = $memoizedProvider()->wait();
 
         // If you are connecting to an Elasticsearch instance on AWS, you will need these values as well
         'aws'             => env('AWS_ELASTICSEARCH_ENABLED', false),
-        'aws_region'      => env('AWS_REGION', ''),
+        'aws_region'      => env('AWS_DEFAULT_REGION', ''),
         'aws_key'         => env('AWS_ACCESS_KEY_ID', ''),
         'aws_secret'      => env('AWS_SECRET_ACCESS_KEY', '')
         'aws_credentials' => $credentials

--- a/config/elasticsearch.php
+++ b/config/elasticsearch.php
@@ -49,7 +49,7 @@ return [
 
                     // If you are connecting to an Elasticsearch instance on AWS, you will need these values as well
                     'aws'               => env('AWS_ELASTICSEARCH_ENABLED', false),
-                    'aws_region'        => env('AWS_REGION', ''),
+                    'aws_region'        => env('AWS_DEFAULT_REGION', ''),
                     'aws_key'           => env('AWS_ACCESS_KEY_ID', ''),
                     'aws_secret'        => env('AWS_SECRET_ACCESS_KEY', ''),
                     'aws_credentials'   => null,


### PR DESCRIPTION
Update the env variable name for AWS region to be the same as the one that Laravel generally uses.
