### PR TITLE
Laravel 7 and php8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^7.11",
         "guzzlehttp/psr7": "^1.7",
-        "illuminate/contracts": "^8.0",
-        "illuminate/support": "^8.0",
+        "illuminate/contracts": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hello, I have laravel 7 and php 7.4 in my project and everything works well. Now I am trying to upgrade php to version 8.0 and get version incompatibility error. Laravel is using the illuminate ^7.0 packages, and your package is using illuminate ^8.0. Thus, I cannot update the php version. Please accept this pull request! 