### PR TITLE
Undefined index api_id issue for version 10

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -181,7 +181,10 @@ class Factory
         }
 
         // Build and return the client
-        if ($host['api_id'] !== null && $host['api_key'] !== null) {
+        if (
+             !empty($host['api_id']) && $host['api_id'] !== null &&
+             !empty($host['api_key']) && $host['api_key'] !== null
+         ) {
             $clientBuilder->setApiKey($host['api_id'], $host['api_key']);
         }
 


### PR DESCRIPTION
This issue is blocking laravel 10 upgrade process. This issue fixed for v9 but not for v10 of that package.
Ref: [issue](https://github.com/cviebrock/laravel-elasticsearch/issues/142)

<img width="1005" alt="Screenshot 2023-06-02 at 1 16 30 PM" src="https://github.com/cviebrock/laravel-elasticsearch/assets/21066418/1e1ad135-c9d5-415a-b273-d43ff62b0239">
