### PR TITLE
Bump elasticsearch php package version to 7.17 (To Remove Deprecated Warning)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "elasticsearch/elasticsearch": "^7.11",
+        "elasticsearch/elasticsearch": "^7.17",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",


### PR DESCRIPTION
## Change
- Bump elasticsearch php package version to 7.17 to remove Deprecated warning (Related [PR](https://github.com/elastic/elasticsearch-php/pull/1417))
<img width="1505" alt="Screenshot 2025-03-04 at 3 04 09 PM" src="https://github.com/user-attachments/assets/9378358b-6fd9-4426-9c3f-ce1e72e15f0b" />
