### PR TITLE
Fix PHP 8.4 deprecation

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -51,7 +51,7 @@ class Manager
      *
      * @return \Elasticsearch\Client
      */
-    public function connection(string $name = null): Client
+    public function connection(?string $name = null): Client
     {
         $name = $name ?: $this->getDefaultConnection();
 


### PR DESCRIPTION
PHP message: PHP Deprecated:
MailerLite\LaravelElasticsearch\Manager::connection(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead

Changelog entries:
https://www.php.net/manual/en/migration84.deprecated.php



Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/laravel-elasticsearch/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [ ] added tests
- [ ] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

**Thank you!**
